### PR TITLE
fix nonce for 32-bit systems

### DIFF
--- a/Pages/IndieAuth/Token.php
+++ b/Pages/IndieAuth/Token.php
@@ -68,7 +68,7 @@
                             'scope'        => 'post',
                             'client_id'    => $client_id,
                             'issued_at'    => time(),
-                            'nonce'        => mt_rand(1000000, pow(2, 31))
+                            'nonce'        => mt_rand(1000000, pow(2, 30))
                         );
                         $user->indieauth_tokens   = $indieauth_tokens;
                         $user->save();


### PR DESCRIPTION
2^31 is too big for 32-bit systems, so just cap at 2^30 instead as a cheap fix.
