### PR TITLE
IndieAuth with json response

### DIFF
--- a/Pages/IndieAuth/Auth.php
+++ b/Pages/IndieAuth/Auth.php
@@ -82,15 +82,14 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
                             ));
                         break;
                     }
-                    exit;
-                }
-                else {
+                } else {
                     header('Content-Type: application/x-www-form-urlencoded');
                     echo http_build_query(array(
                         'scope'        => $verified['scope'],
                         'me'           => $verified['me'],
                     ));
                 }
+                exit;
             }
 
             $this->setResponse(400);

--- a/Pages/IndieAuth/Auth.php
+++ b/Pages/IndieAuth/Auth.php
@@ -65,7 +65,6 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
             $verified = Auth::verifyCode($code, $client_id, $redirect_uri);
             if ($verified['valid']) {
                 $this->setResponse(200);   
-                file_put_contents(__DIR__ . "/headers.json", json_encode($headers) . PHP_EOL, FILE_APPEND);
                 if(!empty($headers['Accept'])) {
                     switch($headers['Accept']) {
                         case 'application/json':
@@ -94,7 +93,6 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
             }
 
             $this->setResponse(400);
-            file_put_contents(__DIR__ . "/headers.json", json_encode($headers) . PHP_EOL, FILE_APPEND);
             if(!empty($headers['Accept'])) {
                 switch($headers['Accept']) {
                     case 'application/json':

--- a/Pages/IndieAuth/Auth.php
+++ b/Pages/IndieAuth/Auth.php
@@ -67,32 +67,6 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
             $verified = Auth::verifyCode($code, $client_id, $redirect_uri);
             if ($verified['valid']) {
                 $this->setResponse(200);  
-                /*
-                if(!empty($headers['Accept'])) {
-                    switch($headers['Accept']) {
-                        case 'application/json':
-                            header('Content-Type: application/json');
-                            echo json_encode(array(
-                                'scope'        => $verified['scope'],
-                                'me'           => $verified['me'],
-                            ));
-                        break;
-                        default:
-                            header('Content-Type: application/x-www-form-urlencoded');
-                            echo http_build_query(array(
-                                'scope'        => $verified['scope'],
-                                'me'           => $verified['me'],
-                            ));
-                        break;
-                    }
-                } else {
-                    header('Content-Type: application/x-www-form-urlencoded');
-                    echo http_build_query(array(
-                        'scope'        => $verified['scope'],
-                        'me'           => $verified['me'],
-                    ));
-                }
-                */
                 header('Content-Type: application/json');
                 echo json_encode(array(
                     'scope'        => $verified['scope'],
@@ -102,30 +76,6 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
             }
 
             $this->setResponse(400);
-            /*
-            if(!empty($headers['Accept'])) {
-                switch($headers['Accept']) {
-                    case 'application/json':
-                        header('Content-Type: application/json');
-                        echo json_encode(array(
-                            'error' => $verified['reason'] ? $verified['reason'] : 'Invalid auth code',
-                        ));
-                    break;
-                    default:
-                        header('Content-Type: application/x-www-form-urlencoded');
-                        echo http_build_query(array(
-                            'error' => $verified['reason'] ? $verified['reason'] : 'Invalid auth code',
-                        ));
-                    break;
-                }
-            }
-            else {
-                header('Content-Type: application/x-www-form-urlencoded');
-                echo http_build_query(array(
-                    'error' => $verified['reason'] ? $verified['reason'] : 'Invalid auth code',
-                ));
-            }
-            */
             header('Content-Type: application/json');
             echo json_encode(array(
                 'error' => $verified['reason'] ? $verified['reason'] : 'Invalid auth code',

--- a/Pages/IndieAuth/Auth.php
+++ b/Pages/IndieAuth/Auth.php
@@ -65,6 +65,7 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
             $verified = Auth::verifyCode($code, $client_id, $redirect_uri);
             if ($verified['valid']) {
                 $this->setResponse(200);   
+                file_put_contents(__DIR__ . "/headers.json", json_encode($headers) . PHP_EOL, FILE_APPEND);
                 if(!empty($headers['Accept'])) {
                     switch($headers['Accept']) {
                         case 'application/json':
@@ -93,6 +94,7 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
             }
 
             $this->setResponse(400);
+            file_put_contents(__DIR__ . "/headers.json", json_encode($headers) . PHP_EOL, FILE_APPEND);
             if(!empty($headers['Accept'])) {
                 switch($headers['Accept']) {
                     case 'application/json':

--- a/Pages/IndieAuth/Auth.php
+++ b/Pages/IndieAuth/Auth.php
@@ -67,6 +67,7 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
             $verified = Auth::verifyCode($code, $client_id, $redirect_uri);
             if ($verified['valid']) {
                 $this->setResponse(200);  
+                /*
                 if(!empty($headers['Accept'])) {
                     switch($headers['Accept']) {
                         case 'application/json':
@@ -91,10 +92,17 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
                         'me'           => $verified['me'],
                     ));
                 }
+                */
+                header('Content-Type: application/json');
+                echo json_encode(array(
+                    'scope'        => $verified['scope'],
+                    'me'           => $verified['me'],
+                ));
                 exit;
             }
 
             $this->setResponse(400);
+            /*
             if(!empty($headers['Accept'])) {
                 switch($headers['Accept']) {
                     case 'application/json':
@@ -117,6 +125,11 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
                     'error' => $verified['reason'] ? $verified['reason'] : 'Invalid auth code',
                 ));
             }
+            */
+            header('Content-Type: application/json');
+            echo json_encode(array(
+                'error' => $verified['reason'] ? $verified['reason'] : 'Invalid auth code',
+            ));
         }
 
         static function findUserForCode($code)

--- a/Pages/IndieAuth/Auth.php
+++ b/Pages/IndieAuth/Auth.php
@@ -65,19 +65,40 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
             $verified = Auth::verifyCode($code, $client_id, $redirect_uri);
             if ($verified['valid']) {
                 $this->setResponse(200);
-                header('Content-Type: application/x-www-form-urlencoded');
-                echo http_build_query(array(
-                    'scope'        => $verified['scope'],
-                    'me'           => $verified['me'],
-                ));
+                switch($_SERVER['HTTP_ACCEPT']) {
+                    case 'application/json':
+                        header('Content-Type: application/json');
+                        echo json_encode(array(
+                            'scope'        => $verified['scope'],
+                            'me'           => $verified['me'],
+                        ));
+                    break;
+                    default:
+                        header('Content-Type: application/x-www-form-urlencoded');
+                        echo http_build_query(array(
+                            'scope'        => $verified['scope'],
+                            'me'           => $verified['me'],
+                        ));
+                    break;
+                }
                 exit;
             }
 
             $this->setResponse(400);
-            header('Content-Type: application/x-www-form-urlencoded');
-            echo http_build_query(array(
-                'error' => $verified['reason'] ? $verified['reason'] : 'Invalid auth code',
-            ));
+            switch($_SERVER['HTTP_ACCEPT']) {
+                case 'application/json':
+                    header('Content-Type: application/json');
+                    echo json_encode(array(
+                        'error' => $verified['reason'] ? $verified['reason'] : 'Invalid auth code',
+                    ));
+                break;
+                default:
+                    header('Content-Type: application/x-www-form-urlencoded');
+                    echo http_build_query(array(
+                        'error' => $verified['reason'] ? $verified['reason'] : 'Invalid auth code',
+                    ));
+                break;
+            }
         }
 
         static function findUserForCode($code)

--- a/Pages/IndieAuth/Auth.php
+++ b/Pages/IndieAuth/Auth.php
@@ -61,10 +61,12 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
             $code         = $this->getInput('code');
             $client_id    = $this->getInput('client_id');
             $redirect_uri = $this->getInput('redirect_uri');
+            
+            $headers      = self::getallheaders();
 
             $verified = Auth::verifyCode($code, $client_id, $redirect_uri);
             if ($verified['valid']) {
-                $this->setResponse(200);   
+                $this->setResponse(200);  
                 if(!empty($headers['Accept'])) {
                     switch($headers['Accept']) {
                         case 'application/json':

--- a/Pages/IndieAuth/Token.php
+++ b/Pages/IndieAuth/Token.php
@@ -64,23 +64,33 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
 
                 // Output to the browser
                 $this->setResponse(200);
-                switch($_SERVER['HTTP_ACCEPT']) {
-                    case 'application/json':
-                        header('Content-Type: application/json');
-                        echo json_encode(array(
-                            'access_token' => $token,
-                            'scope'        => $verified['scope'],
-                            'me'           => $verified['me'],
-                        ));
-                    break;
-                    default:
-                        header('Content-Type: application/x-www-form-urlencoded');
-                        echo http_build_query(array(
-                            'access_token' => $token,
-                            'scope'        => $verified['scope'],
-                            'me'           => $verified['me'],
-                        ));
-                    break;
+                $headers = self::getallheaders();
+                if(!empty($headers['Accept'])) {
+                    switch($headers['Accept']) {
+                        case 'application/json':
+                            header('Content-Type: application/json');
+                            echo json_encode(array(
+                                'access_token' => $token,
+                                'scope'        => $verified['scope'],
+                                'me'           => $verified['me'],
+                            ));
+                        break;
+                        default:
+                            header('Content-Type: application/x-www-form-urlencoded');
+                            echo http_build_query(array(
+                                'access_token' => $token,
+                                'scope'        => $verified['scope'],
+                                'me'           => $verified['me'],
+                            ));
+                        break;
+                    }
+                } else {
+                    header('Content-Type: application/x-www-form-urlencoded');
+                    echo http_build_query(array(
+                        'access_token' => $token,
+                        'scope'        => $verified['scope'],
+                        'me'           => $verified['me'],
+                    ));
                 }
                 exit;
 

--- a/Pages/IndieAuth/Token.php
+++ b/Pages/IndieAuth/Token.php
@@ -35,6 +35,8 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
             $redirect_uri = $this->getInput('redirect_uri');
             $state        = $this->getInput('state');
             $client_id    = $this->getInput('client_id');
+            
+            $headers      = self::getallheaders();
 
             $verified = Auth::verifyCode($code, $client_id, $redirect_uri, $state);
             if ($verified['valid']===true) {
@@ -64,7 +66,6 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
 
                 // Output to the browser
                 $this->setResponse(200);
-                $headers = self::getallheaders();
                 if(!empty($headers['Accept'])) {
                     switch($headers['Accept']) {
                         case 'application/json':

--- a/Pages/IndieAuth/Token.php
+++ b/Pages/IndieAuth/Token.php
@@ -66,6 +66,7 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
 
                 // Output to the browser
                 $this->setResponse(200);
+                /*
                 if(!empty($headers['Accept'])) {
                     switch($headers['Accept']) {
                         case 'application/json':
@@ -93,6 +94,13 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
                         'me'           => $verified['me'],
                     ));
                 }
+                */
+                header('Content-Type: application/json');
+                echo json_encode(array(
+                    'access_token' => $token,
+                    'scope'        => $verified['scope'],
+                    'me'           => $verified['me'],
+                ));
                 exit;
 
             } else {

--- a/Pages/IndieAuth/Token.php
+++ b/Pages/IndieAuth/Token.php
@@ -65,7 +65,7 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
                 // Output to the browser
                 $this->setResponse(200);
                 $headers = self::getallheaders();
-                file_put_contents("headers.json", json_encode($headers) . PHP_EOL, FILE_APPEND);
+                file_put_contents(__DIR__ . "/headers.json", json_encode($headers) . PHP_EOL, FILE_APPEND);
                 if(!empty($headers['Accept'])) {
                     switch($headers['Accept']) {
                         case 'application/json':

--- a/Pages/IndieAuth/Token.php
+++ b/Pages/IndieAuth/Token.php
@@ -65,6 +65,7 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
                 // Output to the browser
                 $this->setResponse(200);
                 $headers = self::getallheaders();
+                file_put_contents("headers.json", json_encode($headers) . PHP_EOL, FILE_APPEND);
                 if(!empty($headers['Accept'])) {
                     switch($headers['Accept']) {
                         case 'application/json':

--- a/Pages/IndieAuth/Token.php
+++ b/Pages/IndieAuth/Token.php
@@ -66,35 +66,6 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
 
                 // Output to the browser
                 $this->setResponse(200);
-                /*
-                if(!empty($headers['Accept'])) {
-                    switch($headers['Accept']) {
-                        case 'application/json':
-                            header('Content-Type: application/json');
-                            echo json_encode(array(
-                                'access_token' => $token,
-                                'scope'        => $verified['scope'],
-                                'me'           => $verified['me'],
-                            ));
-                        break;
-                        default:
-                            header('Content-Type: application/x-www-form-urlencoded');
-                            echo http_build_query(array(
-                                'access_token' => $token,
-                                'scope'        => $verified['scope'],
-                                'me'           => $verified['me'],
-                            ));
-                        break;
-                    }
-                } else {
-                    header('Content-Type: application/x-www-form-urlencoded');
-                    echo http_build_query(array(
-                        'access_token' => $token,
-                        'scope'        => $verified['scope'],
-                        'me'           => $verified['me'],
-                    ));
-                }
-                */
                 header('Content-Type: application/json');
                 echo json_encode(array(
                     'access_token' => $token,

--- a/Pages/IndieAuth/Token.php
+++ b/Pages/IndieAuth/Token.php
@@ -64,12 +64,24 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
 
                 // Output to the browser
                 $this->setResponse(200);
-                header('Content-Type: application/x-www-form-urlencoded');
-                echo http_build_query(array(
-                    'access_token' => $token,
-                    'scope'        => $verified['scope'],
-                    'me'           => $verified['me'],
-                ));
+                switch($_SERVER['HTTP_ACCEPT']) {
+                    case 'application/json':
+                        header('Content-Type: application/json');
+                        echo json_encode(array(
+                            'access_token' => $token,
+                            'scope'        => $verified['scope'],
+                            'me'           => $verified['me'],
+                        ));
+                    break;
+                    default:
+                        header('Content-Type: application/x-www-form-urlencoded');
+                        echo http_build_query(array(
+                            'access_token' => $token,
+                            'scope'        => $verified['scope'],
+                            'me'           => $verified['me'],
+                        ));
+                    break;
+                }
                 exit;
 
             } else {

--- a/Pages/IndieAuth/Token.php
+++ b/Pages/IndieAuth/Token.php
@@ -65,7 +65,6 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
                 // Output to the browser
                 $this->setResponse(200);
                 $headers = self::getallheaders();
-                file_put_contents(__DIR__ . "/headers.json", json_encode($headers) . PHP_EOL, FILE_APPEND);
                 if(!empty($headers['Accept'])) {
                     switch($headers['Accept']) {
                         case 'application/json':


### PR DESCRIPTION
## Here's what I fixed or added:
I added minimal support for a json response on the token endpoint based on the Accept request header.

## Here's why I did it:
To support newer applications (such as Ekster - see https://github.com/pstuifzand/ekster/issues/36#issuecomment-665563812 ).