### PR TITLE
Updating to use the modern forwarding mechanism

### DIFF
--- a/Pages/IndieAuth/Auth.php
+++ b/Pages/IndieAuth/Auth.php
@@ -31,7 +31,7 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
             // not logged in? they'll need to enter their password
             if (!($user = \Idno\Core\site()->session()->currentUser())) {
                 // Do login and redirect workflow
-                $this->forward('/session/login?fwd=' . urlencode($this->currentUrl()));
+                $this->forwardToLogin($this->currentUrl());
                 exit;
             }
 
@@ -61,12 +61,12 @@ namespace IdnoPlugins\IndiePub\Pages\IndieAuth {
             $code         = $this->getInput('code');
             $client_id    = $this->getInput('client_id');
             $redirect_uri = $this->getInput('redirect_uri');
-            
+
             $headers      = self::getallheaders();
 
             $verified = Auth::verifyCode($code, $client_id, $redirect_uri);
             if ($verified['valid']) {
-                $this->setResponse(200);  
+                $this->setResponse(200);
                 header('Content-Type: application/json');
                 echo json_encode(array(
                     'scope'        => $verified['scope'],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "idno/indiepub",
     "description": "Support IndieAuth and Micropub for single-user Known sites. Must be used with a single-user theme.",
     "type": "known-plugin",
-    "version": "0.9.12",
+    "version": "0.9.13",
     "require": {
         "composer/installers": "~1.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "IndiePub",
-    "version": "0.9.10",
+    "version": "0.9.13",
     "devDependencies": {
         "grunt": "^0.4.5"
     }


### PR DESCRIPTION
Indiepub now uses the forward to login introduced in Known. This fixes a bug in Indiepub that was breaking clients that attempted to connect when the user was not logged in.